### PR TITLE
Add NGINX Reverse Proxy with Load Balancing and HTTPS Support

### DIFF
--- a/mini_zanzibar/Dockerfile
+++ b/mini_zanzibar/Dockerfile
@@ -1,0 +1,19 @@
+
+FROM golang:latest
+
+WORKDIR /app
+
+COPY ./cmd ./cmd
+COPY ./internal ./internal
+COPY ./tests ./tests
+COPY ./.env ./.env
+COPY ./.air.toml ./.air.toml
+COPY ./go.mod ./go.mod
+COPY ./go.sum ./go.sum
+
+
+RUN go build -o main cmd/api/main.go
+
+EXPOSE 8080
+
+CMD ["./main"]

--- a/mini_zanzibar/docker-compose.yml
+++ b/mini_zanzibar/docker-compose.yml
@@ -1,18 +1,30 @@
 version: '3.8'
 
 services:
-#  redis:
-#    image: redis:7.2.4
-#    restart: always
-#    ports:
-#      - "${DB_PORT}:6379"
+  nginx:
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/resources:/var/www/resources
+    depends_on:
+      - go_app
+    networks:
+      - app_network
+
   consul:
     image: hashicorp/consul
     command: ["consul", "agent", "-dev", "-client", "0.0.0.0"]
     ports:
       - "8500:8500"
+    networks:
+      - app_network
+
   psql:
-    image: postgres:latest
+    image: postgres:15
     environment:
       POSTGRES_DB: ${DB_DATABASE}
       POSTGRES_USER: ${DB_USERNAME}
@@ -21,6 +33,25 @@ services:
       - "${DB_PORT}:5432"
     volumes:
       - ./data/postgresql:/var/lib/postgresql/data
+    networks:
+      - app_network
 
-volumes:
-  psql_volume:
+  go_app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PORT: 8080
+    deploy:
+      replicas: 3
+    ports:
+      - "8080-8082:8080"
+    depends_on:
+      - psql
+      - consul
+    networks:
+      - app_network
+
+networks:
+  app_network:
+    driver: bridge

--- a/mini_zanzibar/internal/database/consul.go
+++ b/mini_zanzibar/internal/database/consul.go
@@ -3,6 +3,7 @@ package database
 import (
 	capi "github.com/hashicorp/consul/api"
 	"log"
+	"os"
 )
 
 type ConsulService interface {
@@ -15,8 +16,15 @@ type consulService struct {
 	client *capi.Client
 }
 
+var (
+	consulAddress = os.Getenv("CONSUL_ADDRESS")
+)
+
 func NewConsulService() ConsulService {
 	config := capi.DefaultConfig()
+	if consulAddress != "" {
+		config.Address = consulAddress
+	}
 	client, err := capi.NewClient(config)
 	if err != nil {
 		log.Fatalf("failed to create Consul client: %v", err)

--- a/mini_zanzibar/nginx/Dockerfile
+++ b/mini_zanzibar/nginx/Dockerfile
@@ -1,0 +1,18 @@
+FROM nginx:latest
+
+RUN apt-get -y update \
+    && apt-get install openssl
+
+RUN mkdir /etc/nginx/ssl
+
+RUN openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+        -keyout /etc/nginx/ssl/example.key \
+        -out /etc/nginx/ssl/example.crt \
+        -subj "/C=RS/ST=Serbia/L=NoviSad/O=42/OU=42/CN=example/UID=example"
+
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY ./resources /var/www/resources
+
+EXPOSE 80
+EXPOSE 443

--- a/mini_zanzibar/nginx/nginx.conf
+++ b/mini_zanzibar/nginx/nginx.conf
@@ -1,0 +1,52 @@
+
+upstream app_servers {
+    server go_app:8080;
+    server go_app:8081;
+    server go_app:8082;
+}
+
+
+server {
+	listen 80 default_server;
+	
+	return 301 https://$host$request_uri;
+	
+}
+
+server {
+	listen 443 ssl;
+
+	set $localhost_param go_app;
+# 	set $api_gateway https://api.gg.com;
+	
+	ssl_certificate /etc/nginx/ssl/example.crt;
+	ssl_certificate_key /etc/nginx/ssl/example.key;
+	
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+	ssl_ciphers HIGH:!aNULL:!MD5;
+	
+	resolver 8.8.8.8;
+
+	location / {
+		proxy_pass        http://app_servers;
+# 		proxy_set_header Authorization '';
+		proxy_set_header  X-Real-IP $remote_addr;
+		proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+ 		proxy_set_header  Host $http_host;
+		proxy_set_header  'Access-Control-Allow-Origin' '*';
+		add_header 'Access-Control-Allow-Origin' '*';
+		add_header 'Access-Control-Allow-Headers' '*';
+		add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+		proxy_ssl_server_name on;
+                proxy_ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+                proxy_buffering off;
+                proxy_hide_header Set-Cookie;
+                proxy_ignore_headers Set-Cookie;
+	}
+	
+	#location /static/public/ {
+	#	add_header 'Access-Control-Allow-Origin' '*';
+	#	root /var/www/resources;
+	#}
+
+}

--- a/mini_zanzibar/nginx/resources/index.html
+++ b/mini_zanzibar/nginx/resources/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>


### PR DESCRIPTION
- Set up NGINX as a reverse proxy.
- Configured NGINX as a load balancer for three go application instances running on ports 8080, 8081, and 8082.
- Added SSL/TLS certificates for HTTPS support.
- Redirected all HTTP traffic (port 80) to HTTPS (port 443).